### PR TITLE
ci: add Next.js build cache to frontend workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -49,6 +49,14 @@ jobs:
       - run: pnpm run format:check
       - run: pnpm run type:check
       - run: pnpm run test
+      - name: Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: pwa/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pwa/pnpm-lock.yaml') }}-${{ hashFiles('pwa/**/*.ts', 'pwa/**/*.tsx', 'pwa/**/*.js', 'pwa/**/*.jsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pwa/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
       - name: Build
         run: pnpm run build
       - name: Prepare Standalone Artifact

--- a/pwa/next.config.ts
+++ b/pwa/next.config.ts
@@ -13,6 +13,7 @@ const nextConfig: NextConfig = {
     }
     return config;
   },
+  // Transpile required packages for API Platform and React Admin
   transpilePackages: [
     "@api-platform/admin",
     "@api-platform/api-doc-parser",


### PR DESCRIPTION
Adds the `actions/cache@v4` step to `.github/workflows/frontend.yml` right before the Next.js `Build` step to significantly improve build times by caching the `.next/cache` directory. The step uses a cache key based on the OS, the `pwa/pnpm-lock.yaml` file, and the hash of all Next.js source files. Validated the YAML syntax and ran tests to ensure no regressions.

---
*PR created automatically by Jules for task [7658808063142269739](https://jules.google.com/task/7658808063142269739) started by @Jules-Rabus*